### PR TITLE
First attempt at GH-action managed releases.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { rust: stable,           os: ubuntu-latest }
-          - { rust: stable,           os: macos-latest }
-          - { rust: beta,             os: ubuntu-latest }
+          - rust: stable
+            os: ubuntu-latest
+          - rust: stable
+            os: macos-latest
+          - rust: beta
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Create release
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  RUST_BACKTRACE: full
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: "Release ${{ github.ref }}"
+          body: "<INSERT RELEASE DETAILS HERE>"
+          draft: true
+          prerelease: false
+
+  build:
+    name: Build and upload the binary
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: nquery
+            asset_name: nquery-linux-amd64
+          - os: macos-latest
+            artifact_name: nquery
+            asset_name: nquery-macos-amd64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build project
+        run: cargo build --release --locked
+      - name: Upload binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: target/release/${{ matrix.artifact_name }}
+          asset_name: ${{ matrix.asset_name }}
+          asset_content_type: application/octet-stream

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Don't actually commit any nomad manifests
+*.nomad
 
 # Created by https://www.toptal.com/developers/gitignore/api/vim,linux,rust
 # Edit at https://www.toptal.com/developers/gitignore?templates=vim,linux,rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Query your Nomad clusters"
 homepage = "https://github.io/sparkmeter/nquery"
 repository = "https://github.com/sparkmeter/nquery"
 readme = "README.md"
-keywords = ["git", "gitlab", "github"]
+keywords = ["nomad", "hashicorp"]
 categories = ["command-line-utilities"]
 license = "MIT"
 


### PR DESCRIPTION
On tag push matching `v*`, a new draft gh release will be created for the tag, the binary built for Linux and MacOS, and uploaded to the GH release.

The release draft body can then be edited, and the release published.