### PR TITLE
Correct JobListing types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ keywords = ["nomad", "hashicorp"]
 categories = ["command-line-utilities"]
 license = "MIT"
 
+[badges]
+is-it-maintained-issue-resolution = { repository = "sparkmeter/nquery" }
+is-it-maintained-open-issues = { repository = "sparkmeter/nquery" }
+maintenance = {status = "actively-developed"}
+
 [dependencies]
 color-backtrace = "0.4"
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build](https://github.com/sparkmeter/nquery/workflows/CI/badge.svg)]
+[![Latest version](https://img.shields.io/crates/v/nquery.svg?style=flat)](https://crates.io/crates/nquery)]
+
 # nquery
 Query and explore jobs on your Nomad clusters.
 

--- a/src/nomad.rs
+++ b/src/nomad.rs
@@ -76,6 +76,7 @@ impl Client {
     }
 }
 
+/// Get the Nomad client
 pub fn get_client() -> Client {
     Client {
         address: match std::env::var("NOMAD_ADDR") {


### PR DESCRIPTION
Jobs and JobListings actually have two distinct types for certain fields, with the former having more detail. This applies the distinction for periodic and parameterized jobs.